### PR TITLE
JV 2015: Erhöhung des Säumniszuschlags

### DIFF
--- a/Finanzordnung.md
+++ b/Finanzordnung.md
@@ -77,7 +77,7 @@
 ## § 5 Überschreiten von Zahlungsfristen
 
 1.  
-    Werden für Veranstaltungen, die von der DSJ organisiert und durchgeführt werden oder an denen sich die DSJ beteiligt, in den jeweiligen Ausschreibungen bzw. Einladungen Fristen oder Stichtage für die Zahlung von Teilnehmerbeiträgen gesetzt und werden diese nicht eingehalten, ist der Finanzreferent berechtigt einen Säumniszuschlag zu erheben. Der Säumniszuschlag beträgt 2% und richtet sich nach der Höhe der zu zahlenden Teilnehmerbeiträge. Bereits gezahlte Beiträge werden dabei berücksichtigt.
+    Werden für Veranstaltungen, die von der DSJ organisiert und durchgeführt werden oder an denen sich die DSJ beteiligt, in den jeweiligen Ausschreibungen bzw. Einladungen Fristen oder Stichtage für die Zahlung von Teilnehmerbeiträgen gesetzt und werden diese nicht eingehalten, ist der Finanzreferent berechtigt einen Säumniszuschlag zu erheben. Der Säumniszuschlag beträgt 10% aber max. 100 Euro und richtet sich nach der Höhe der zu zahlenden Teilnehmerbeiträge. Bereits gezahlte Beiträge werden dabei berücksichtigt.
 
 1.  
     Spieler und Mannschaften können von Veranstaltungen der DSJ ausgeschlossen werden, wenn die Fristen oder Stichtage für die Zahlung von Teilnehmerbeträgen nicht eingehalten wurden und vom Finanzreferenten erfolglos eine Nachfrist von 7 Tagen gesetzt wurde.


### PR DESCRIPTION
> # Antrag des AK Spielbetrieb zur Finanzordnung
> 
> _(siehe Commit 6872e00)_
> **Begründung:**
> Es kommt immer wieder vor, dass einzelne Vereine (z.B. bei der DVM) deutlich verspätet bezahlen. Der Säumniszuschlag von 2% ist so gering, dass die Drohung diesen zu verhängen wirkungslos bleibt.
> Die Obergrenze von 100 Euro soll insbesondere die Länder schützen, die sonst bei der DEM schnell zu sehr hohen Säumniszuschlägen verurteilt werden könnten.
